### PR TITLE
Update StoryRouter.js

### DIFF
--- a/src/StoryRouter.js
+++ b/src/StoryRouter.js
@@ -128,7 +128,7 @@ class HistoryWatcher extends Component {
   }
 
   componentWillUnmount() {
-    this.unlisten();
+    this.unlisten && this.unlisten();
   }
 
   onHistoryChanged(location, historyAction) {

--- a/src/StoryRouter.js
+++ b/src/StoryRouter.js
@@ -128,7 +128,14 @@ class HistoryWatcher extends Component {
   }
 
   componentWillUnmount() {
-    this.unlisten && this.unlisten();
+    // If an exception occurs during a custom componentDidMount hook the
+    // HistoryWatcher::componentDidMount method will not be called and so
+    // the unlisten method will not be defined.
+    if (!this.unlisten) {
+      return;
+    }
+
+    this.unlisten();
   }
 
   onHistoryChanged(location, historyAction) {


### PR DESCRIPTION
when there is some exception during initialization of my story, componentWillMount is called without componentWillMount being called first, which leads to the case when unlisten is not defined. This change allows me to see real exception, not 'this.unlisten is not a function' which says nothing about my exception. I am not sure if it is valid that willUnmount is called before componentDidMount, but this change just fixes the issue.