### PR TITLE
loosen up react-router version ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "prop-types": "^15.5.10",
     "react": "^0.14.7 || ^15.0.0",
-    "react-router": "^3.0.0 || ^4.0.0",
+    "react-router": "^3.0 || ^4.0",
     "vue": "^2.4.4",
     "vue-router": "^2.7.0",
     "@storybook/addon-actions": "^3.2.10"


### PR DESCRIPTION
This applies caret ranges at the minor level instead of the patch level. Currently, a project depending on `storybook-router` can pull the latest patch versions of `react-router`, but only for minor versions 3.0 or 4.0. If there is a project that uses a later minor version of react-router v3 or v4, then there will be a version conflict. For example, if I am using yarn and my project depends on `react-router@^4.2`, then the following warning will be printed on `yarn install`:

```
warning "storybook-router@0.2.9" has unmet peer dependency "react-router@^3.0.0 || ^4.0.0"
```

What's also strange to me is that I could theoretically jump from react-router 3.0.x to react-router v4.0.x, but not any of the react-router 3.x versions with a minor version > 0.

When I look at the existing code in `package.json`, I interpret the intent to be "pull all applicable versions of React Router v3 or v4".  My change in this PR will match this intent more accurately.