### PR TITLE
change return value Vue to Object

### DIFF
--- a/src/vue.js
+++ b/src/vue.js
@@ -67,7 +67,7 @@ const storyRouterDecorator = (links = {}, routerProps = {}) => {
     });
 
     const WrappedComponent = story();
-    return Vue.extend({
+    return {
       router,
       components: { WrappedComponent },
       template: '<wrapped-component/>',
@@ -78,7 +78,7 @@ const storyRouterDecorator = (links = {}, routerProps = {}) => {
         // times as the VueRouter instance has been created)
         this.$options.router.afterHooks = [];
       },
-    });
+    };
   };
 };
 


### PR DESCRIPTION
I think the return value of decorator func should be Object.
When I used this mock router with other decorator, there are some confricts and 'addDecorator' registed globaly in 'config.js' did not work.
I don't know architecture of storybook and vue-router in detail, what do you think?