### PR TITLE
Export StoryRouter

### DIFF
--- a/src/react.js
+++ b/src/react.js
@@ -171,4 +171,6 @@ const storyRouterDecorator = (links, routerProps) => {
   return s;
 };
 
+export { StoryRouter }
+
 export default storyRouterDecorator;

--- a/src/react.js
+++ b/src/react.js
@@ -171,6 +171,6 @@ const storyRouterDecorator = (links, routerProps) => {
   return s;
 };
 
-export { StoryRouter }
+export { StoryRouter };
 
 export default storyRouterDecorator;


### PR DESCRIPTION
Tiny change with important impact. My use case for using StoryRouter component directly is two-fold. 

For once I have my own decorator used across all stories and it bundles together stuff like ThemeProvider, MobX Provider, Apollo Provider, etc... so I don't need to specify that one by one in each story and yet I can customize the behavior per story. I want to add `StoryRouter` into the mix.

The second reason is that decorator is applied to all stories in a file. I want a more fine-grained approach to set a different config for router per story.