### PR TITLE
Add information on how to add StoryRouter globally

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -59,11 +59,13 @@ If you want to use `StoryRouter` in all your stories, you can also add it global
 import { configure, addDecorator } from '@storybook/react';
 import StoryRouter from 'storybook-react-router';
 
-// ...your config
-
 addDecorator(StoryRouter());
 
+// ...your config
+
 ```
+
+The important thing is to call `addDecorator` before calling `configure`, otherwise it will not work!
 
 ## StoryRouter arguments
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -53,6 +53,18 @@ storiesOf('Params', module)
   ));
 ```
 
+If you want to use `StoryRouter` in all your stories, you can also add it globally by edditing your Storybook `config.js` file:
+
+```js
+import { configure, addDecorator } from '@storybook/react';
+import StoryRouter from 'storybook-react-router';
+
+// ...your config
+
+addDecorator(StoryRouter());
+
+```
+
 ## StoryRouter arguments
 
 The **first argument** is an object that you can use to extend the default behavior.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -53,7 +53,7 @@ storiesOf('Params', module)
   ));
 ```
 
-If you want to use `StoryRouter` in all your stories, you can also add it globally by edditing your Storybook `config.js` file:
+If you want to use `StoryRouter` in all your stories, you can also add it globally by editing your Storybook `config.js` file:
 
 ```js
 import { configure, addDecorator } from '@storybook/react';


### PR DESCRIPTION
The docs suggest that you have to add the `StoryRouter` manually to each story. This adds the docs on how to do it for all of the stories at once.