### PR TITLE
Upgrade dependencies

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,8 +19,8 @@
     "react-router"
   ],
   "peerDependencies": {
-    "@storybook/addon-actions": "^3.0.0",
-    "@storybook/addons": "^3.0.0",
+    "@storybook/addon-actions": ">=3.0.0",
+    "@storybook/addons": ">=3.0.0",
     "react": "*",
     "react-dom": "*",
     "react-router": "^4.0.0"
@@ -29,8 +29,8 @@
     "prop-types": "^15.6.1"
   },
   "devDependencies": {
-    "@storybook/addon-actions": "^3.3.15",
-    "@storybook/addons": "^3.3.15",
+    "@storybook/addon-actions": "^4.0.9",
+    "@storybook/addons": "^4.0.9",
     "babel-cli": "^6.24.1",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",


### PR DESCRIPTION
I tested this package with the latest storybook and it works great. Can we update dependencies to avoid annoying messages from npm?

```
npm WARN storybook-react-router@1.0.1 requires a peer of @storybook/addon-actions@^3.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN storybook-react-router@1.0.1 requires a peer of @storybook/addons@^3.0.0 but none is installed. You must install peer dependencies yourself.
``` 
