### PR TITLE
Update README to reflect Storybook 6 changes

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -60,7 +60,7 @@ export default {
 If you want to use `StoryRouter` in all your stories, you can also add it globally by editing your Storybook `preview.js` file:
 
 ```js
-import StoryRouter from 'storybook-react-router';
+import { StoryRouter } from 'storybook-react-router';
 
 /** Global decorators. */
 export const decorators = [

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -41,31 +41,39 @@ export default ComponentParams;
 you can add the `StoryRouter` decorator to your story this way:
 
 ```js
-import { storiesOf } from '@storybook/react';
 import StoryRouter from 'storybook-react-router';
 
-import ComponentParams from '<your_component_path>/ComponentParams';
+import YourComponent from './YourComponentPath';
 
-storiesOf('Params', module)
-  .addDecorator(StoryRouter())
-  .add('params', () => (
-    <ComponentParams/>
-  ));
+export default {
+  component: YourComponent,
+  decorators: [
+    (Story) => (
+      <StoryRouter>
+        <Story />
+      </StoryRouter>
+    )
+  ]
+}
 ```
 
-If you want to use `StoryRouter` in all your stories, you can also add it globally by editing your Storybook `config.js` file:
+If you want to use `StoryRouter` in all your stories, you can also add it globally by editing your Storybook `preview.js` file:
 
 ```js
-import { configure, addDecorator } from '@storybook/react';
 import StoryRouter from 'storybook-react-router';
 
-addDecorator(StoryRouter());
+/** Global decorators. */
+export const decorators = [
+  (Story) => (
+    <StoryRouter>
+      <Story />
+    </StoryRouter>
+  ),
+]
 
 // ...your config
 
 ```
-
-The important thing is to call `addDecorator` before calling `configure`, otherwise it will not work!
 
 ## StoryRouter arguments
 


### PR DESCRIPTION
`addDecorator` and `storiesOf` are both deprecated, but this still seems to work fine with Storybook 6. Updated to reflect changes in their API.

https://github.com/storybookjs/storybook/blob/next/CHANGELOG.md#600-beta42-july-5-2020
https://github.com/storybookjs/storybook/blob/next/CHANGELOG.md#600-beta37-june-26-2020