### PR TITLE
Upgrade peer dependencies

### DIFF
--- a/examples/react-router/package.json
+++ b/examples/react-router/package.json
@@ -17,9 +17,9 @@
     "react-router"
   ],
   "dependencies": {
-    "@storybook/addon-actions": "^4.0.9||^5.0.2||5.2.0-beta.13",
+    "@storybook/addon-actions": "^4.0.9||^5.0.2||5.2.0-beta.13||^6.1.21",
     "@storybook/addon-links": "^4.0.9||^5.0.2||5.2.0-beta.13",
-    "@storybook/react": "^4.0.9||^5.0.2||5.2.0-beta.13",
+    "@storybook/react": "^4.0.9||^5.0.2||5.2.0-beta.13||^6.1.21",
     "prop-types": "^15.7.2",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,7 +19,7 @@
     "react-router"
   ],
   "peerDependencies": {
-    "@storybook/addon-actions": "^4.0.0||^5.0.0||5.2.0-beta.13",
+    "@storybook/addon-actions": "^4.0.0||^5.0.0||5.2.0-beta.13||^6.1.21",
     "react": "*",
     "react-dom": "*",
     "react-router": "^4.0.0||^5.0.0"
@@ -28,7 +28,7 @@
     "prop-types": "^15.7.2"
   },
   "devDependencies": {
-    "@storybook/addon-actions": "^4.0.9||^5.0.2||5.2.0-beta.13",
+    "@storybook/addon-actions": "^4.0.9||^5.0.2||5.2.0-beta.13||^6.1.21",
     "babel-cli": "^6.24.1",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",


### PR DESCRIPTION
Hi, I've tested with `@storybook/addon-actions@6.1.21` to safely remove this warning:

`npm WARN storybook-react-router@1.0.8 requires a peer of @storybook/addon-actions@^4.0.0||^5.0.0||5.2.0-beta.13 but none is installed. You must install peer dependencies yourself.`

Can you please check this PR and merge changes?

p.s. I've updated `@storybook/react` version too in `examples` because it matches too with my test environment
